### PR TITLE
Claim help, fly & MiniMessage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,23 @@
 plugins {
 	id 'fabric-loom' version '0.4-SNAPSHOT'
 	id 'maven-publish'
+    id "com.github.johnrengelman.shadow" version "5.2.0"
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 archivesBaseName = project.archives_base_name
-version = project.mod_version
 group = project.maven_group
+version = "${project.mod_version}-${project.minecraft_version}"
+String jarpath = "${project.buildDir}/libs/${project.archivesBaseName}-${project.version}"
+
+// Shadow stuff
+configurations {
+    dev
+    compile.extendsFrom shade
+    modCompile.extendsFrom modShade
+}
 
 repositories {
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
@@ -27,6 +36,24 @@ dependencies {
     compile "net.kyori:adventure-text-serializer-gson:${project.kyori_adventure_version}"
 }
 
+// Tasks
+shadowJar {
+    enabled = true
+    // Only shadow implementation/modImplementation
+    configurations = [project.configurations.shade]
+    classifier = "dev"
+}
+
+task remapShadowJar(type: net.fabricmc.loom.task.RemapJarTask, dependsOn: shadowJar) {
+    afterEvaluate {
+        input = file("${jarpath}-dev.jar")
+        archiveName = "${project.name}-${project.version}.jar"
+        addNestedDependencies = true
+        remapAccessWidener = true
+    }
+}
+
+
 processResources {
 	inputs.property "version", project.version
 
@@ -39,6 +66,9 @@ processResources {
 		exclude "fabric.mod.json"
 	}
 }
+
+build.dependsOn(shadowJar, remapShadowJar)
+
 
 // ensure that the encoding is set to UTF-8, no matter what the system default is
 // this fixes some edge cases with special characters not displaying correctly

--- a/src/main/java/me/drex/itsours/claim/permission/util/PermissionMap.java
+++ b/src/main/java/me/drex/itsours/claim/permission/util/PermissionMap.java
@@ -1,5 +1,8 @@
 package me.drex.itsours.claim.permission.util;
 
+import me.drex.itsours.util.Color;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.MutableText;
@@ -42,14 +45,12 @@ public class PermissionMap extends HashMap<String, Boolean> {
         return this.containsKey(permission);
     }
 
-    public Text toText() {
-        boolean color = false;
-        MutableText text = new LiteralText("");
+    public Component toText() {
+        TextComponent.Builder text = Component.text();
         for (Entry<String, Boolean> entry : this.entrySet()) {
-            text.append(new LiteralText(entry.getKey()).formatted(entry.getValue() ? color ? Formatting.DARK_GREEN : Formatting.GREEN : color ? Formatting.DARK_RED : Formatting.RED)).append(" ");
-            color = !color;
+            text.append(Component.text(entry.getKey()).color(entry.getValue() ? Color.LIGHT_GREEN : Color.RED).append(Component.text(" ")));
         }
-        return text;
+        return text.build();
     }
 
 }

--- a/src/main/java/me/drex/itsours/command/BlocksCommand.java
+++ b/src/main/java/me/drex/itsours/command/BlocksCommand.java
@@ -7,9 +7,12 @@ import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import me.drex.itsours.ItsOursMod;
 import me.drex.itsours.user.ClaimPlayer;
+import me.drex.itsours.util.Color;
+import net.kyori.adventure.text.Component;
 import net.minecraft.command.argument.GameProfileArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
 public class BlocksCommand extends Command {
@@ -50,25 +53,25 @@ public class BlocksCommand extends Command {
 
     public int check(ServerCommandSource source) throws CommandSyntaxException {
         int blocks = ItsOursMod.INSTANCE.getBlockManager().getBlocks(source.getPlayer().getUuid());
-        ((ClaimPlayer) source.getPlayer()).sendMessage(new LiteralText("You have " + blocks + " blocks left").formatted(Formatting.GREEN));
+        ((ClaimPlayer) source.getPlayer()).sendMessage(Component.text("You have " + blocks + " blocks left").color(Color.LIGHT_GREEN));
         return blocks;
     }
 
     public int checkOther(ServerCommandSource source, GameProfile gameProfile) throws CommandSyntaxException {
         int blocks = ItsOursMod.INSTANCE.getBlockManager().getBlocks(gameProfile.getId());
-        ((ClaimPlayer) source.getPlayer()).sendMessage(new LiteralText(gameProfile.getName() + " has " + blocks + " blocks left").formatted(Formatting.GREEN));
+        ((ClaimPlayer) source.getPlayer()).sendMessage(Component.text(gameProfile.getName() + " has " + blocks + " blocks left").color(Color.LIGHT_GREEN));
         return blocks;
     }
 
     public int set(ServerCommandSource source, GameProfile gameProfile, int amount) throws CommandSyntaxException {
         ItsOursMod.INSTANCE.getBlockManager().setBlocks(gameProfile.getId(), amount);
-        ((ClaimPlayer) source.getPlayer()).sendMessage(new LiteralText("Set " + gameProfile.getName() + "'s claim blocks to " + amount).formatted(Formatting.GREEN));
+        ((ClaimPlayer) source.getPlayer()).sendMessage(Component.text("Set " + gameProfile.getName() + "'s claim blocks to " + amount).color(Color.LIGHT_GREEN));
         return amount;
     }
 
     public int add(ServerCommandSource source, GameProfile gameProfile, int amount) throws CommandSyntaxException {
         ItsOursMod.INSTANCE.getBlockManager().addBlocks(gameProfile.getId(), amount);
-        ((ClaimPlayer) source.getPlayer()).sendMessage(new LiteralText((amount > 0 ? ("Added " + amount) : ("Removed " + -amount)) + " claim block(s) " + (amount > 0 ? "to " : "from ") + gameProfile.getName()).formatted(Formatting.GREEN));
+        ((ClaimPlayer) source.getPlayer()).sendMessage(Component.text((amount > 0 ? ("Added " + amount) : ("Removed " + -amount)) + " claim block(s) " + (amount > 0 ? "to " : "from ") + gameProfile.getName()).color(Color.LIGHT_GREEN));
         return amount;
     }
 

--- a/src/main/java/me/drex/itsours/command/ColorCommand.java
+++ b/src/main/java/me/drex/itsours/command/ColorCommand.java
@@ -1,0 +1,29 @@
+package me.drex.itsours.command;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import me.drex.itsours.user.ClaimPlayer;
+import me.drex.itsours.util.Color;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.TextColor;
+import net.minecraft.server.command.ServerCommandSource;
+
+public class ColorCommand extends Command {
+
+    public void register(LiteralArgumentBuilder<ServerCommandSource> literal) {
+        LiteralArgumentBuilder<ServerCommandSource> command = LiteralArgumentBuilder.literal("colors");
+        command.executes(ctx -> showColors(ctx.getSource()));
+        literal.then(command);
+    }
+
+    public int showColors(ServerCommandSource source) throws CommandSyntaxException {
+        TextComponent.Builder textComponent = Component.text().content("ItsOurs Color Palette:\n\n").color(Color.GRAY);
+        for (Color color : Color.COLORS) {
+            textComponent.append(Component.text(color.name.toUpperCase() + " ").color(color));
+        }
+        ((ClaimPlayer)source.getPlayer()).sendMessage(textComponent.build());
+        return 1;
+    }
+
+}

--- a/src/main/java/me/drex/itsours/command/ColorCommand.java
+++ b/src/main/java/me/drex/itsours/command/ColorCommand.java
@@ -6,7 +6,6 @@ import me.drex.itsours.user.ClaimPlayer;
 import me.drex.itsours.util.Color;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
-import net.kyori.adventure.text.format.TextColor;
 import net.minecraft.server.command.ServerCommandSource;
 
 public class ColorCommand extends Command {

--- a/src/main/java/me/drex/itsours/command/CreateCommand.java
+++ b/src/main/java/me/drex/itsours/command/CreateCommand.java
@@ -10,6 +10,7 @@ import me.drex.itsours.claim.AbstractClaim;
 import me.drex.itsours.claim.Claim;
 import me.drex.itsours.claim.Subzone;
 import me.drex.itsours.user.ClaimPlayer;
+import net.minecraft.block.Block;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.Formatting;
@@ -66,6 +67,8 @@ public class CreateCommand extends Command {
             claimPlayer.setRightPosition(null);
             return 1;
         } else {
+            Block.getBlockFromItem()
+            claimPlayer.sendMessage(new LiteralText("You need to select the corners of your claim with a golden shovel (left- / rightclick)").formatted(Formatting.RED));
             return 0;
         }
 

--- a/src/main/java/me/drex/itsours/command/CreateCommand.java
+++ b/src/main/java/me/drex/itsours/command/CreateCommand.java
@@ -39,25 +39,26 @@ public class CreateCommand extends Command {
             BlockPos max = new BlockPos(claimPlayer.getRightPosition());
             max = new BlockPos(max.getX(), 256, max.getZ());
             if (!AbstractClaim.isNameValid(name))
-                throw new SimpleCommandExceptionType(TextComponentUtil.from(Component.text("Claim name is to long or contains invalid characters").color(Color.RED))).create();
+                throw new SimpleCommandExceptionType(TextComponentUtil.error("Claim name is to long or contains invalid characters")).create();
             AbstractClaim claim = new Claim(name, source.getPlayer().getUuid(), min, max, source.getWorld(), null);
             if (claim.intersects()) {
                 AbstractClaim parent = ItsOursMod.INSTANCE.getClaimList().get(source.getWorld(), min);
                 if (parent != null && parent.contains(max)) {
                     for (Subzone subzone : parent.getSubzones()) {
                         if (subzone.getName().equals(name))
-                            throw new SimpleCommandExceptionType(new LiteralText("Claim name is already taken")).create();
+                            throw new SimpleCommandExceptionType(TextComponentUtil.error("Claim name is already taken")).create();
                     }
                     claim = new Subzone(name, source.getPlayer().getUuid(), min, max, source.getWorld(), null, parent);
                 } else {
-                    throw new SimpleCommandExceptionType(new LiteralText("Claim couldn't be created, because it would overlap with another claim")).create();
+                    throw new SimpleCommandExceptionType(TextComponentUtil.error("Claim couldn't be created, because it would overlap with another claim")).create();
                 }
             } else {
                 if (ItsOursMod.INSTANCE.getBlockManager().getBlocks(source.getPlayer().getUuid()) < claim.getArea())
-                    throw new SimpleCommandExceptionType(new LiteralText("You don't have enough claim blocks")).create();
+                    throw new SimpleCommandExceptionType(TextComponentUtil.error("You don't have enough claim blocks")).create();
                 if (ItsOursMod.INSTANCE.getClaimList().contains(name))
-                    throw new SimpleCommandExceptionType(new LiteralText("Claim name is already taken")).create();
-                ((ClaimPlayer) source.getPlayer()).sendMessage(new LiteralText("Claim created!").formatted(Formatting.GREEN));
+                    throw new SimpleCommandExceptionType(TextComponentUtil.error("Claim name is already taken")).create();
+                BlockPos size = claim.getSize();
+                ((ClaimPlayer) source.getPlayer()).sendMessage(Component.text("Claim " + name + " has been created (" + size.getX() + " x " + size.getY() + " x " + size.getZ() + ")").color(Color.LIGHT_GREEN));
             }
             if (claimPlayer.getLastShowClaim() != null) claimPlayer.getLastShowClaim().show(source.getPlayer(), false);
             claimPlayer.setLastShow(claim, source.getPlayer().getBlockPos(), source.getWorld());
@@ -70,7 +71,7 @@ public class CreateCommand extends Command {
             claimPlayer.setRightPosition(null);
             return 1;
         } else {
-            claimPlayer.sendMessage(new LiteralText("You need to select the corners of your claim with a golden shovel (left- / rightclick)").formatted(Formatting.RED));
+            claimPlayer.sendMessage(Component.text("You need to select the corners of your claim with a golden shovel (left- / rightclick) first.").color(Color.RED));
             return 0;
         }
 

--- a/src/main/java/me/drex/itsours/command/CreateCommand.java
+++ b/src/main/java/me/drex/itsours/command/CreateCommand.java
@@ -67,7 +67,6 @@ public class CreateCommand extends Command {
             claimPlayer.setRightPosition(null);
             return 1;
         } else {
-            Block.getBlockFromItem()
             claimPlayer.sendMessage(new LiteralText("You need to select the corners of your claim with a golden shovel (left- / rightclick)").formatted(Formatting.RED));
             return 0;
         }

--- a/src/main/java/me/drex/itsours/command/CreateCommand.java
+++ b/src/main/java/me/drex/itsours/command/CreateCommand.java
@@ -10,6 +10,9 @@ import me.drex.itsours.claim.AbstractClaim;
 import me.drex.itsours.claim.Claim;
 import me.drex.itsours.claim.Subzone;
 import me.drex.itsours.user.ClaimPlayer;
+import me.drex.itsours.util.Color;
+import me.drex.itsours.util.TextComponentUtil;
+import net.kyori.adventure.text.Component;
 import net.minecraft.block.Block;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.LiteralText;
@@ -36,7 +39,7 @@ public class CreateCommand extends Command {
             BlockPos max = new BlockPos(claimPlayer.getRightPosition());
             max = new BlockPos(max.getX(), 256, max.getZ());
             if (!AbstractClaim.isNameValid(name))
-                throw new SimpleCommandExceptionType(new LiteralText("Claim name is to long or contains invalid characters")).create();
+                throw new SimpleCommandExceptionType(TextComponentUtil.from(Component.text("Claim name is to long or contains invalid characters").color(Color.RED))).create();
             AbstractClaim claim = new Claim(name, source.getPlayer().getUuid(), min, max, source.getWorld(), null);
             if (claim.intersects()) {
                 AbstractClaim parent = ItsOursMod.INSTANCE.getClaimList().get(source.getWorld(), min);

--- a/src/main/java/me/drex/itsours/command/FlyCommand.java
+++ b/src/main/java/me/drex/itsours/command/FlyCommand.java
@@ -22,7 +22,13 @@ public class FlyCommand extends Command {
         ServerPlayerEntity player = source.getPlayer();
         ClaimPlayer claimPlayer = (ClaimPlayer) player;
         claimPlayer.toggleFlight();
-        if (ItsOursMod.INSTANCE.getClaimList().get(player.getServerWorld(), player.getBlockPos()) != null) player.abilities.allowFlying = claimPlayer.flightEnabled();
+        if (ItsOursMod.INSTANCE.getClaimList().get(player.getServerWorld(), player.getBlockPos()) != null) {
+            player.interactionManager.getGameMode().setAbilities(player.abilities);
+            if (claimPlayer.flightEnabled()) {
+                player.abilities.allowFlying = true;
+            }
+            player.sendAbilitiesUpdate();
+        }
         claimPlayer.sendMessage(Component.text("Claim flight " + (claimPlayer.flightEnabled() ? "enabled" : "disabled")).color(claimPlayer.flightEnabled() ? Color.LIGHT_GREEN : Color.RED));
         return 1;
     }

--- a/src/main/java/me/drex/itsours/command/FlyCommand.java
+++ b/src/main/java/me/drex/itsours/command/FlyCommand.java
@@ -2,13 +2,12 @@ package me.drex.itsours.command;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import me.drex.itsours.ItsOursMod;
 import me.drex.itsours.user.ClaimPlayer;
 import me.drex.itsours.util.Color;
 import net.kyori.adventure.text.Component;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.LiteralText;
-import net.minecraft.util.Formatting;
 
 public class FlyCommand extends Command {
 
@@ -23,6 +22,7 @@ public class FlyCommand extends Command {
         ServerPlayerEntity player = source.getPlayer();
         ClaimPlayer claimPlayer = (ClaimPlayer) player;
         claimPlayer.toggleFlight();
+        if (ItsOursMod.INSTANCE.getClaimList().get(player.getServerWorld(), player.getBlockPos()) != null) player.abilities.allowFlying = claimPlayer.flightEnabled();
         claimPlayer.sendMessage(Component.text("Claim flight " + (claimPlayer.flightEnabled() ? "enabled" : "disabled")).color(claimPlayer.flightEnabled() ? Color.LIGHT_GREEN : Color.RED));
         return 1;
     }

--- a/src/main/java/me/drex/itsours/command/FlyCommand.java
+++ b/src/main/java/me/drex/itsours/command/FlyCommand.java
@@ -3,6 +3,8 @@ package me.drex.itsours.command;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import me.drex.itsours.user.ClaimPlayer;
+import me.drex.itsours.util.Color;
+import net.kyori.adventure.text.Component;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.LiteralText;
@@ -21,7 +23,7 @@ public class FlyCommand extends Command {
         ServerPlayerEntity player = source.getPlayer();
         ClaimPlayer claimPlayer = (ClaimPlayer) player;
         claimPlayer.toggleFlight();
-        claimPlayer.sendMessage(new LiteralText("Claim flight " + (claimPlayer.flightEnabled() ? "enabled" : "disabled")).formatted(claimPlayer.flightEnabled() ? Formatting.GREEN : Formatting.RED));
+        claimPlayer.sendMessage(Component.text("Claim flight " + (claimPlayer.flightEnabled() ? "enabled" : "disabled")).color(claimPlayer.flightEnabled() ? Color.LIGHT_GREEN : Color.RED));
         return 1;
     }
 

--- a/src/main/java/me/drex/itsours/command/ListCommand.java
+++ b/src/main/java/me/drex/itsours/command/ListCommand.java
@@ -9,6 +9,10 @@ import me.drex.itsours.claim.AbstractClaim;
 import me.drex.itsours.claim.Claim;
 import me.drex.itsours.claim.Subzone;
 import me.drex.itsours.user.ClaimPlayer;
+import me.drex.itsours.util.Color;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.minecraft.command.argument.GameProfileArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.*;
@@ -31,27 +35,27 @@ public class ListCommand extends Command {
     public int list(ServerCommandSource source, GameProfile target) throws CommandSyntaxException {
         List<AbstractClaim> claims = ItsOursMod.INSTANCE.getClaimList().get(target.getId());
         if (claims.isEmpty()) {
-            ((ClaimPlayer) source.getPlayer()).sendMessage(new LiteralText("No claims").formatted(Formatting.RED));
+            ((ClaimPlayer) source.getPlayer()).sendMessage(Component.text("No claims").color(Color.RED));
             return 0;
         }
-        MutableText text = new LiteralText("Claims (" + target.getName() + ") \n").formatted(Formatting.GOLD);
+        TextComponent.Builder builder = Component.text().content("Claims (" + target.getName() + ") \n").color(Color.ORANGE);
         boolean color = false;
         boolean color2 = false;
         for (AbstractClaim claim : claims) {
             if (claim instanceof Claim) {
-                MutableText hover = new LiteralText("");
+                TextComponent.Builder hover = Component.text();
                 if (!claim.getSubzones().isEmpty()) {
-                    hover.append("Subzones: \n").formatted(Formatting.BLUE);
+                    hover.append(Component.text("Subzones: \n").color(Color.LIGHT_BLUE));
                     for (Subzone subzone : claim.getSubzones()) {
-                        hover.append(new LiteralText(subzone.getName() + " ").formatted(color2 ? Formatting.LIGHT_PURPLE : Formatting.DARK_PURPLE));
+                        hover.append(Component.text(subzone.getName() + " ").color(color2 ? Color.PURPLE : Color.DARK_PURPLE));
                         color2 = !color2;
                     }
                 }
-                text.append(new LiteralText(claim.getName() + " ").formatted(color ? Formatting.AQUA : Formatting.DARK_AQUA).styled(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/claim info " + claim.getName())).withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hover))));
+                builder.append(Component.text(claim.getName() + " ").color(color ? Color.AQUA : Color.BLUE)).clickEvent(net.kyori.adventure.text.event.ClickEvent.runCommand("/claim info " + claim.getName())).style((style) -> style.hoverEvent(HoverEvent.showText(hover.build())));
                 color = !color;
             }
         }
-        ((ClaimPlayer) source.getPlayer()).sendMessage(text);
+        ((ClaimPlayer) source.getPlayer()).sendMessage(builder.build());
         return claims.size();
     }
 }

--- a/src/main/java/me/drex/itsours/command/Manager.java
+++ b/src/main/java/me/drex/itsours/command/Manager.java
@@ -9,6 +9,7 @@ public class Manager {
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
         LiteralArgumentBuilder<ServerCommandSource> main = LiteralArgumentBuilder.literal("claim");
         new BlocksCommand().register(main);
+        new ColorCommand().register(main);
         new CreateCommand().register(main);
         new ExpandCommand().register(main);
         new FlyCommand().register(main);

--- a/src/main/java/me/drex/itsours/command/PermissionCommand.java
+++ b/src/main/java/me/drex/itsours/command/PermissionCommand.java
@@ -12,9 +12,12 @@ import me.drex.itsours.claim.permission.PermissionManager;
 import me.drex.itsours.claim.permission.roles.Role;
 import me.drex.itsours.claim.permission.util.Permission;
 import me.drex.itsours.user.ClaimPlayer;
+import me.drex.itsours.util.Color;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.minecraft.command.argument.GameProfileArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
-import net.minecraft.text.HoverEvent;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.MutableText;
 import net.minecraft.util.Formatting;
@@ -68,55 +71,56 @@ public class PermissionCommand extends Command {
         //TODO: Check if excutor is allowed to check
         boolean value = claim.hasPermission(target.getId(), permission);
         String perm = permission;
-        MutableText hover = new LiteralText("");
+        TextComponent.Builder hover = Component.text();
         hover.append(checkPermission(claim.getPermissionManager(), target, permission));
         while (permission.contains(".")) {
             String[] node = permission.split("\\.");
             permission = permission.substring(0, (permission.length() - (node[node.length-1]).length() - 1));
-            hover.append("\n");
+            hover.append(Component.text("\n"));
             hover.append(checkPermission(claim.getPermissionManager(), target, permission));
         }
-        ((ClaimPlayer) source.getPlayer()).sendMessage(new LiteralText(target.getName() + " (").formatted(Formatting.YELLOW)
-                .append(new LiteralText(perm).formatted(Formatting.GOLD))
-                .append(new LiteralText("): ").formatted(Formatting.YELLOW)
-                .append(format(value)).styled(style -> style.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hover)))));
+        ((ClaimPlayer) source.getPlayer()).sendMessage(Component.text(target.getName() + " (").color(Color.YELLOW)
+                .append(Component.text(perm).color(Color.ORANGE))
+                .append(Component.text("): ").color(Color.YELLOW))
+                .append(format(value).style(style -> style.hoverEvent(HoverEvent.showText(hover.build())))));
         return 1;
     }
 
-    public MutableText checkPermission(PermissionManager pm, GameProfile target, String permission) {
-        MutableText hover = new LiteralText(permission + ":").formatted(Formatting.LIGHT_PURPLE)
-                .append(new LiteralText("\n -Settings: ")
-                .formatted(Formatting.YELLOW)
-                .append(pm.settings.isPermissionSet(permission) ? format(pm.settings.getPermission(permission)) : new LiteralText("unset").formatted(Formatting.GRAY)));
+    public Component checkPermission(PermissionManager pm, GameProfile target, String permission) {
+        TextComponent.Builder hover = Component.text()
+                .append(Component.text(permission + ":").color(Color.PINK))
+                .append(Component.text("\n -Settings: ").color(Color.YELLOW))
+                .append(pm.settings.isPermissionSet(permission) ? format(pm.settings.getPermission(permission)) : Component.text("unset").color(Color.GRAY));
 
-        MutableText roles = new LiteralText("\n -Roles: ").formatted(Formatting.YELLOW);
+        TextComponent.Builder roles = Component.text().content("\n -Roles: ").color(Color.YELLOW);
         for (Role role : pm.getRolesByWeight(target.getId())) {
-            roles.append(new LiteralText("\n  *" + ItsOursMod.INSTANCE.getRoleManager().getRoleID(role) + " (").formatted(Formatting.YELLOW))
-                    .append(new LiteralText(String.valueOf(pm.roles.get(target.getId()).get(role))).formatted(Formatting.GOLD)
-                            .append(new LiteralText( "): ").formatted(Formatting.YELLOW))
-                            .append(role.permissions().isPermissionSet(permission) ? format(role.permissions().getPermission(permission)) : new LiteralText("unset").formatted(Formatting.GRAY)));
+            roles.append(Component.text("\n  *" + ItsOursMod.INSTANCE.getRoleManager().getRoleID(role) + " (").color(Color.YELLOW))
+            .append(Component.text(String.valueOf(pm.roles.get(target.getId()).get(role))).color(Color.ORANGE))
+            .append(Component.text("): ").color(Color.YELLOW))
+            .append(role.permissions().isPermissionSet(permission) ? format(role.permissions().getPermission(permission)) : Component.text("unset").color(Color.GRAY));
         }
+
         hover.append(roles);
 
-        hover.append(new LiteralText("\n -Permissions: ").formatted(Formatting.YELLOW).append(pm.isPlayerPermissionSet(target.getId(), permission) ? format(pm.playerPermission.get(target.getId()).getPermission(permission)) : new LiteralText("unset").formatted(Formatting.GRAY)));
-        return hover;
+        hover.append(Component.text("\n -Permissions: ").color(Color.YELLOW)
+            .append(pm.isPlayerPermissionSet(target.getId(), permission) ? format(pm.playerPermission.get(target.getId()).getPermission(permission)) : Component.text("unset").color(Color.GRAY)));
+        return hover.build();
     }
-
     public int setPermission(ServerCommandSource source, AbstractClaim claim, GameProfile target, String permission, boolean value) throws CommandSyntaxException {
         claim.getPermissionManager().setPlayerPermission(target.getId(), permission, value);
-        ((ClaimPlayer) source.getPlayer()).sendMessage(new LiteralText("Set permission ").formatted(Formatting.YELLOW)
-                .append(permission).formatted(Formatting.GOLD)
-                .append(" for ").formatted(Formatting.YELLOW)
-                .append(target.getName()).formatted(Formatting.GOLD).append(" to ").formatted(Formatting.YELLOW).append(format(value)));
+        ((ClaimPlayer) source.getPlayer()).sendMessage(Component.text("Set permission ").color(Color.YELLOW)
+                .append(Component.text(permission)).color(Color.ORANGE)
+                .append(Component.text(" for ")).color(Color.YELLOW)
+                .append(Component.text(target.getName())).color(Color.ORANGE).append(Component.text(" to ")).color(Color.YELLOW).append(format(value)));
         return 0;
     }
 
     public int resetPermission(ServerCommandSource source, AbstractClaim claim, GameProfile target, String permission) throws CommandSyntaxException {
         claim.getPermissionManager().resetPlayerPermission(target.getId(), permission);
-        ((ClaimPlayer) source.getPlayer()).sendMessage(new LiteralText("Reset permission ").formatted(Formatting.YELLOW)
-                .append(permission).formatted(Formatting.GOLD)
-                .append(" for ").formatted(Formatting.YELLOW)
-                .append(target.getName()));
+        ((ClaimPlayer) source.getPlayer()).sendMessage(Component.text("Reset permission ").color(Color.YELLOW)
+                .append(Component.text(permission)).color(Color.ORANGE)
+                .append(Component.text(" for ")).color(Color.YELLOW)
+                .append(Component.text(target.getName())));
         return 0;
     }
 

--- a/src/main/java/me/drex/itsours/command/RemoveCommand.java
+++ b/src/main/java/me/drex/itsours/command/RemoveCommand.java
@@ -9,6 +9,10 @@ import me.drex.itsours.claim.AbstractClaim;
 import me.drex.itsours.claim.Claim;
 import me.drex.itsours.claim.Subzone;
 import me.drex.itsours.user.ClaimPlayer;
+import me.drex.itsours.util.Color;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.LiteralText;
@@ -30,13 +34,10 @@ public class RemoveCommand extends Command {
     public int requestRemove(ServerCommandSource source, AbstractClaim claim) throws CommandSyntaxException {
        validate(source, claim);
        if (!source.getPlayer().getUuid().toString().equals(claim.getOwner().toString())) {
-           ((ClaimPlayer) source.getPlayer()).sendMessage(new LiteralText("WARNING: This is not your claim...").formatted(Formatting.DARK_RED).formatted(Formatting.BOLD));
+           ((ClaimPlayer) source.getPlayer()).sendMessage(Component.text("WARNING: This is not your claim...").color(Color.RED).decorate(TextDecoration.BOLD));
        }
-        ((ClaimPlayer) source.getPlayer()).sendMessage(new LiteralText("Are you sure you want to delete the claim \"" + claim.getName() + "\"? ").formatted(Formatting.RED)
-                .append(new LiteralText("[I'M SURE]").styled(style -> style
-                        .withColor(Formatting.DARK_RED)
-                        .withBold(true)
-                        .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/claim remove " + claim.getName() + " confirm")))));
+        ((ClaimPlayer) source.getPlayer()).sendMessage(Component.text("Are you sure you want to delete the claim \"" + claim.getName() + "\"? ").color(Color.RED)
+                .append(Component.text("[I'M SURE]").clickEvent(net.kyori.adventure.text.event.ClickEvent.runCommand("/claim remove " + claim.getName() + " confirm")).decorate(TextDecoration.BOLD).color(Color.RED)));
        return 0;
     }
 
@@ -53,7 +54,7 @@ public class RemoveCommand extends Command {
         //recursively remove all subzones
         removeSubzones(claim);
         ItsOursMod.INSTANCE.getClaimList().remove(claim);
-        ((ClaimPlayer) source.getPlayer()).sendMessage(new LiteralText("Deleted the claim \"" + claim.getName() + "\" ").formatted(Formatting.GREEN));
+        ((ClaimPlayer) source.getPlayer()).sendMessage(Component.text("Deleted the claim \"" + claim.getName() + "\" ").color(Color.LIGHT_GREEN));
 
         return 0;
     }

--- a/src/main/java/me/drex/itsours/command/RoleCommand.java
+++ b/src/main/java/me/drex/itsours/command/RoleCommand.java
@@ -13,6 +13,9 @@ import me.drex.itsours.claim.AbstractClaim;
 import me.drex.itsours.claim.permission.PermissionManager;
 import me.drex.itsours.claim.permission.roles.Role;
 import me.drex.itsours.user.ClaimPlayer;
+import me.drex.itsours.util.Color;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.argument.GameProfileArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
@@ -68,9 +71,9 @@ public class RoleCommand extends Command {
         if (!ItsOursMod.INSTANCE.getRoleManager().containsKey(name)) throw new SimpleCommandExceptionType(new LiteralText("There is no role with that name")).create();
         Role role = ItsOursMod.INSTANCE.getRoleManager().get(name);
         claim.getPermissionManager().addRole(target.getId(), role, weight);
-        ((ClaimPlayer)source.getPlayer()).sendMessage(new LiteralText("Added ").formatted(Formatting.YELLOW)
-                .append(new LiteralText(name).formatted(Formatting.GOLD)).append(new LiteralText(" to ").formatted(Formatting.YELLOW))
-                .append(new LiteralText(target.getName()).formatted(Formatting.GOLD)));
+        ((ClaimPlayer)source.getPlayer()).sendMessage(Component.text("Added ").color(Color.YELLOW)
+                .append(Component.text(name).color(Color.ORANGE)).append(Component.text(" to ").color(Color.YELLOW))
+                .append(Component.text(target.getName()).color(Color.ORANGE)));
         return 1;
     }
 
@@ -79,20 +82,20 @@ public class RoleCommand extends Command {
         Role role = ItsOursMod.INSTANCE.getRoleManager().get(name);
         if (!claim.getPermissionManager().hasRole(target.getId(), role)) throw new SimpleCommandExceptionType(new LiteralText(target.getName() + " doesn't have a role with that name")).create();
         claim.getPermissionManager().removeRole(target.getId(), role);
-        ((ClaimPlayer)source.getPlayer()).sendMessage(new LiteralText("Removed ").formatted(Formatting.YELLOW)
-                .append(new LiteralText(name).formatted(Formatting.GOLD)).append(new LiteralText(" from ").formatted(Formatting.YELLOW))
-                .append(new LiteralText(target.getName()).formatted(Formatting.GOLD)));
+        ((ClaimPlayer)source.getPlayer()).sendMessage(Component.text("Removed ").color(Color.YELLOW)
+                .append(Component.text(name).color(Color.ORANGE)).append(Component.text(" from ").color(Color.YELLOW))
+                .append(Component.text(target.getName()).color(Color.ORANGE)));
         return 1;
     }
 
     public int listRoles(ServerCommandSource source, AbstractClaim claim, GameProfile target) throws CommandSyntaxException {
-        MutableText text = new LiteralText("Roles (").formatted(Formatting.YELLOW).append(new LiteralText(target.getName()).formatted(Formatting.GOLD).append(new LiteralText("):\n").formatted(Formatting.YELLOW)));
+        TextComponent.Builder builder = Component.text().content("Roles (").color(Color.YELLOW).append(Component.text(target.getName()).color(Color.ORANGE).append(Component.text("):\n").color(Color.YELLOW)));
         PermissionManager pm = claim.getPermissionManager();
-        pm.getRolesByWeight(target.getId()).forEach(role -> text
-            .append(new LiteralText( ItsOursMod.INSTANCE.getRoleManager().getRoleID(role) + " (").formatted(Formatting.YELLOW))
-            .append(new LiteralText(String.valueOf(pm.roles.get(target.getId()).get(role))).formatted(Formatting.GOLD))
-            .append(new LiteralText(")").formatted(Formatting.YELLOW).append(" ")));
-        ((ClaimPlayer)source.getPlayer()).sendMessage(text);
+        pm.getRolesByWeight(target.getId()).forEach(role ->
+            builder.append(Component.text(ItsOursMod.INSTANCE.getRoleManager().getRoleID(role) + " (").color(Color.YELLOW))
+            .append(Component.text(String.valueOf(pm.roles.get(target.getId()).get(role))).color(Color.ORANGE))
+            .append(Component.text(") ").color(Color.YELLOW)));
+        ((ClaimPlayer)source.getPlayer()).sendMessage(builder.build());
         return 1;
     }
 

--- a/src/main/java/me/drex/itsours/command/RolesCommand.java
+++ b/src/main/java/me/drex/itsours/command/RolesCommand.java
@@ -9,6 +9,9 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import me.drex.itsours.ItsOursMod;
 import me.drex.itsours.claim.permission.roles.Role;
 import me.drex.itsours.user.ClaimPlayer;
+import me.drex.itsours.util.Color;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.HoverEvent;
@@ -58,7 +61,8 @@ public class RolesCommand extends Command {
     public int addRole(ServerCommandSource source, String name) throws CommandSyntaxException {
         if (ItsOursMod.INSTANCE.getRoleManager().containsKey(name)) throw new SimpleCommandExceptionType(new LiteralText("A role with that name already exists")).create();
         ItsOursMod.INSTANCE.getRoleManager().put(name, new Role(new CompoundTag()));
-        ((ClaimPlayer)source.getPlayer()).sendMessage(new LiteralText("Role ").formatted(Formatting.YELLOW).append(new LiteralText(name).formatted(Formatting.GOLD).append(new LiteralText(" has been added").formatted(Formatting.YELLOW))));
+        ((ClaimPlayer)source.getPlayer()).sendMessage(Component.text("Role ").color(Color.YELLOW)
+                .append(Component.text(name).color(Color.ORANGE).append(Component.text(" has been added").color(Color.YELLOW))));
 
         return 1;
     }
@@ -66,7 +70,7 @@ public class RolesCommand extends Command {
     public int removeRole(ServerCommandSource source, String name) throws CommandSyntaxException {
         if (!ItsOursMod.INSTANCE.getRoleManager().containsKey(name)) throw new SimpleCommandExceptionType(new LiteralText("There is no role with that name")).create();
         ItsOursMod.INSTANCE.getRoleManager().remove(name);
-        ((ClaimPlayer)source.getPlayer()).sendMessage(new LiteralText("Role ").formatted(Formatting.YELLOW).append(new LiteralText(name).formatted(Formatting.GOLD).append(new LiteralText(" has been removed").formatted(Formatting.YELLOW))));
+        ((ClaimPlayer)source.getPlayer()).sendMessage(Component.text("Role ").color(Color.YELLOW).append(Component.text(name).color(Color.ORANGE).append(Component.text(" has been removed").color(Color.YELLOW))));
         return 1;
     }
 
@@ -74,27 +78,27 @@ public class RolesCommand extends Command {
         if (!ItsOursMod.INSTANCE.getRoleManager().containsKey(name)) throw new SimpleCommandExceptionType(new LiteralText("There is no role with that name")).create();
         Role role = ItsOursMod.INSTANCE.getRoleManager().get(name);
         role.permissions().setPermission(permission, value);
-        ((ClaimPlayer)source.getPlayer()).sendMessage(new LiteralText("Set ").formatted(Formatting.YELLOW)
-                .append(new LiteralText(permission).formatted(Formatting.GOLD)).append(new LiteralText(" for ").formatted(Formatting.YELLOW))
-                .append(new LiteralText(name).formatted(Formatting.GOLD)
-                .append(new LiteralText(" to ").formatted(Formatting.YELLOW)).append(format(value))));
+        ((ClaimPlayer)source.getPlayer()).sendMessage(Component.text("Set ").color(Color.YELLOW)
+                .append(Component.text(permission).color(Color.ORANGE)).append(Component.text(" for ").color(Color.YELLOW))
+                .append(Component.text(name).color(Color.ORANGE)
+                .append(Component.text(" to ").color(Color.YELLOW)).append(format(value))));
         return 1;
     }
 
     public int listPermission(ServerCommandSource source, String name) throws CommandSyntaxException {
         if (!ItsOursMod.INSTANCE.getRoleManager().containsKey(name)) throw new SimpleCommandExceptionType(new LiteralText("There is no role with that name")).create();
         Role role = ItsOursMod.INSTANCE.getRoleManager().get(name);
-        ((ClaimPlayer)source.getPlayer()).sendMessage(new LiteralText(name).formatted(Formatting.YELLOW).append("\n").append(role.permissions().toText()));
+        ((ClaimPlayer)source.getPlayer()).sendMessage(Component.text(name).color(Color.YELLOW).append(Component.text("\n")).append(role.permissions().toText()));
         return 1;
     }
     public int listRoles(ServerCommandSource source) throws CommandSyntaxException {
-        MutableText text = new LiteralText("Roles:\n").formatted(Formatting.GOLD);
+        TextComponent.Builder builder = Component.text().content("Roles:\n").color(Color.ORANGE);
         for (Map.Entry<String, Role> entry : ItsOursMod.INSTANCE.getRoleManager().entrySet()) {
             String name = entry.getKey();
             Role role = entry.getValue();
-            text.append(new LiteralText(name).formatted(Formatting.YELLOW).styled(style -> style.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, role.permissions().toText())))).append(" ");
+            builder.append(Component.text(name).color(Color.YELLOW).style(style -> style.hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(role.permissions().toText())))).append(Component.text(" "));
         }
-        ((ClaimPlayer) source.getPlayer()).sendMessage(text);
+        ((ClaimPlayer) source.getPlayer()).sendMessage(builder.build());
         return 1;
     }
 

--- a/src/main/java/me/drex/itsours/mixin/BlockItemMixin.java
+++ b/src/main/java/me/drex/itsours/mixin/BlockItemMixin.java
@@ -1,0 +1,52 @@
+package me.drex.itsours.mixin;
+
+import me.drex.itsours.user.ClaimPlayer;
+import me.drex.itsours.util.Color;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockWithEntity;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.ChestBlock;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemPlacementContext;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BlockItem.class)
+public abstract class BlockItemMixin extends Item {
+
+    public BlockItemMixin(Settings settings) {
+        super(settings);
+    }
+
+    @Shadow public abstract Block getBlock();
+
+    @Inject(method = "place(Lnet/minecraft/item/ItemPlacementContext;)Lnet/minecraft/util/ActionResult;", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;onPlaced(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/item/ItemStack;)V"))
+    private void ItsOurs$placeBlock(ItemPlacementContext context, CallbackInfoReturnable<ActionResult> cir) {
+        Block block = this.getBlock();
+        BlockPos blockPos = context.getBlockPos();
+        if (block instanceof BlockWithEntity || block == Blocks.CRAFTING_TABLE) {
+            PlayerEntity playerEntity = context.getPlayer();
+            ClaimPlayer claimPlayer = (ClaimPlayer) playerEntity;
+            if (claimPlayer != null) {
+                TextComponent.Builder textComponent = Component.text().content("This " + this.getDefaultStack().getName().getString().toLowerCase() + " is not protected,").color(Color.YELLOW).append(Component.text(" click this ").color(Color.ORANGE)).append(Component.text("message to create a claim, to protect it").color(Color.YELLOW));
+                textComponent.clickEvent(net.kyori.adventure.text.event.ClickEvent.runCommand("/claim create"));
+                claimPlayer.sendMessage(textComponent.build());
+                if (!claimPlayer.arePositionsSet()) {
+                    claimPlayer.setRightPosition(new BlockPos(blockPos.getX() + 3, blockPos.getY(), blockPos.getZ() + 3));
+                    claimPlayer.setLeftPosition(new BlockPos(blockPos.getX() - 3, blockPos.getY(), blockPos.getZ() - 3));
+                }
+            }
+
+        }
+    }
+
+}

--- a/src/main/java/me/drex/itsours/mixin/EntityMixin.java
+++ b/src/main/java/me/drex/itsours/mixin/EntityMixin.java
@@ -41,14 +41,25 @@ public abstract class EntityMixin {
                     Text message = null;
                     if (pclaim != null && claim == null) {
                         //TODO: Make configurable
-                        player.abilities.allowFlying = claimPlayer.getFlightCache();
-                        if (player.abilities.flying && !claimPlayer.getFlightCache()) player.abilities.flying = false;
+                        boolean cachedFlying = player.abilities.flying;
+                        //update abilities for respective gamemode
+                        player.interactionManager.getGameMode().setAbilities(player.abilities);
+                        //check if the player was flying before they entered the claim
+                        if (claimPlayer.getFlightCache()) {
+                            player.abilities.flying = cachedFlying;
+                            player.abilities.allowFlying = true;
+                        }
                         player.sendAbilitiesUpdate();
                         message = new LiteralText("You left " + pclaim.getFullName()).formatted(Formatting.YELLOW);
                     } else if (claim != null) {
                         if (pclaim == null) claimPlayer.cacheFlight(player.abilities.allowFlying);
-                        player.abilities.flying = claimPlayer.flightEnabled();
-                        player.abilities.allowFlying = claimPlayer.flightEnabled();
+                        boolean cachedFlying = player.abilities.flying;
+                        //update abilities for respective gamemode
+                        player.interactionManager.getGameMode().setAbilities(player.abilities);
+                        //enable flying if player enabled it
+                        if (!player.abilities.allowFlying) player.abilities.allowFlying = claimPlayer.flightEnabled();
+                        //set the flight state to what it was before entering
+                        if (player.abilities.allowFlying) player.abilities.flying = cachedFlying;
                         player.sendAbilitiesUpdate();
                         message = new LiteralText("Welcome to " + claim.getFullName()).formatted(Formatting.YELLOW);
                     }

--- a/src/main/java/me/drex/itsours/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/me/drex/itsours/mixin/ServerPlayerEntityMixin.java
@@ -3,7 +3,7 @@ package me.drex.itsours.mixin;
 import com.mojang.authlib.GameProfile;
 import me.drex.itsours.claim.AbstractClaim;
 import me.drex.itsours.user.ClaimPlayer;
-import me.drex.itsours.util.TextComponent;
+import me.drex.itsours.util.TextComponentUtil;
 import net.kyori.adventure.text.Component;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -15,7 +15,6 @@ import net.minecraft.util.Pair;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.GameMode;
 import net.minecraft.world.World;
-import net.minecraft.world.dimension.DimensionType;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -122,7 +121,7 @@ public class ServerPlayerEntityMixin extends  PlayerEntity implements ClaimPlaye
 
     @Override
     public void sendMessage(Component component) {
-        this.sendMessage(TextComponent.from(component), false);
+        this.sendMessage(TextComponentUtil.from(component), false);
     }
 
     @Override

--- a/src/main/java/me/drex/itsours/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/me/drex/itsours/mixin/ServerPlayerEntityMixin.java
@@ -3,6 +3,8 @@ package me.drex.itsours.mixin;
 import com.mojang.authlib.GameProfile;
 import me.drex.itsours.claim.AbstractClaim;
 import me.drex.itsours.user.ClaimPlayer;
+import me.drex.itsours.util.TextComponent;
+import net.kyori.adventure.text.Component;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.network.ServerPlayerInteractionManager;
@@ -116,6 +118,11 @@ public class ServerPlayerEntityMixin extends  PlayerEntity implements ClaimPlaye
     @Override
     public void sendMessage(Text message) {
         this.sendMessage(message, false);
+    }
+
+    @Override
+    public void sendMessage(Component component) {
+        this.sendMessage(TextComponent.from(component), false);
     }
 
     @Override

--- a/src/main/java/me/drex/itsours/mixin/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/me/drex/itsours/mixin/ServerPlayerInteractionManagerMixin.java
@@ -3,22 +3,14 @@ package me.drex.itsours.mixin;
 import me.drex.itsours.ItsOursMod;
 import me.drex.itsours.user.ClaimPlayer;
 import me.drex.itsours.util.Color;
-import me.drex.itsours.util.TextComponentUtil;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
-import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextColor;
-import net.kyori.adventure.text.format.TextDecoration;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.network.ServerPlayerInteractionManager;
-import net.minecraft.text.ClickEvent;
-import net.minecraft.text.LiteralText;
-import net.minecraft.text.MutableText;
 import net.minecraft.util.ActionResult;
-import net.minecraft.util.Formatting;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
@@ -30,8 +22,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.awt.*;
 
 @Mixin(ServerPlayerInteractionManager.class)
 public class ServerPlayerInteractionManagerMixin {
@@ -48,15 +38,6 @@ public class ServerPlayerInteractionManagerMixin {
             claimPlayer.setRightPosition(pos);
             onClaimAddCorner();
         }
-        //TODO: Make sure the chest was actually placed
-//        if (stack.getItem() == Items.CHEST && ItsOursMod.INSTANCE.getClaimList().get(player.getUuid()).isEmpty()) {
-//            claimPlayer.sendMessage(Component.text("This " + stack.getName().getString().toLowerCase() + " is not protected, click this message to create a claim, to protect it").color(Color.ORANGE).clickEvent(net.kyori.adventure.text.event.ClickEvent.runCommand("/claim create")));
-//            BlockPos blockPos = hitResult.getBlockPos().offset(hitResult.getSide());
-//            if (!claimPlayer.arePositionsSet()) {
-//                claimPlayer.setRightPosition(new BlockPos(blockPos.getX() + 3, blockPos.getY(), blockPos.getZ() + 3));
-//                claimPlayer.setLeftPosition(new BlockPos(blockPos.getX() - 3, blockPos.getY(), blockPos.getZ() - 3));
-//            }
-//        }
     }
 
     @Inject(method = "processBlockBreakingAction", at = @At("HEAD"))

--- a/src/main/java/me/drex/itsours/mixin/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/me/drex/itsours/mixin/ServerPlayerInteractionManagerMixin.java
@@ -5,6 +5,7 @@ import me.drex.itsours.user.ClaimPlayer;
 import me.drex.itsours.util.Color;
 import me.drex.itsours.util.TextComponentUtil;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -30,6 +31,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.awt.*;
+
 @Mixin(ServerPlayerInteractionManager.class)
 public class ServerPlayerInteractionManagerMixin {
 
@@ -47,8 +50,7 @@ public class ServerPlayerInteractionManagerMixin {
         }
         //TODO: Make sure the chest was actually placed
         if (stack.getItem() == Items.CHEST && ItsOursMod.INSTANCE.getClaimList().get(player.getUuid()).isEmpty()) {
-            claimPlayer.sendMessage(new LiteralText("This " + stack.getName().getString().toLowerCase() + " is not protected, click this message to create a claim, to protect it").formatted(Formatting.GOLD)
-                    .styled(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/claim create"))));
+            claimPlayer.sendMessage(Component.text("This " + stack.getName().getString().toLowerCase() + " is not protected, click this message to create a claim, to protect it").color(Color.ORANGE).clickEvent(net.kyori.adventure.text.event.ClickEvent.runCommand("/claim create")));
             BlockPos blockPos = hitResult.getBlockPos().offset(hitResult.getSide());
             if (!claimPlayer.arePositionsSet()) {
                 claimPlayer.setRightPosition(new BlockPos(blockPos.getX() + 3, blockPos.getY(), blockPos.getZ() + 3));
@@ -70,13 +72,13 @@ public class ServerPlayerInteractionManagerMixin {
     public void onClaimAddCorner() {
         ClaimPlayer claimPlayer = (ClaimPlayer) player;
         if (claimPlayer.arePositionsSet()) {
-            MutableText text = new LiteralText("Area Selected. Click to create your claim!").formatted(Formatting.GOLD);
+            TextComponent.Builder builder =  Component.text().content("Area Selected. Click to create your claim!").color(Color.ORANGE);
             if (ItsOursMod.INSTANCE.getClaimList().get(player.getUuid()).isEmpty()) {
-                text.styled(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/claim create " + player.getEntityName())));
+                builder.clickEvent(net.kyori.adventure.text.event.ClickEvent.runCommand("/claim create " + player.getEntityName()));
             } else {
-                text.styled(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/claim create <name>")));
+                builder.clickEvent(net.kyori.adventure.text.event.ClickEvent.suggestCommand("/claim create name"));
             }
-            claimPlayer.sendMessage(text);
+            claimPlayer.sendMessage(builder.build());
         }
     }
 

--- a/src/main/java/me/drex/itsours/mixin/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/me/drex/itsours/mixin/ServerPlayerInteractionManagerMixin.java
@@ -2,6 +2,7 @@ package me.drex.itsours.mixin;
 
 import me.drex.itsours.ItsOursMod;
 import me.drex.itsours.user.ClaimPlayer;
+import me.drex.itsours.util.TextComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
@@ -55,7 +56,7 @@ public class ServerPlayerInteractionManagerMixin {
     private void onMine(BlockPos pos, PlayerActionC2SPacket.Action action, Direction direction, int worldHeight, CallbackInfo ci) {
         ClaimPlayer claimPlayer = (ClaimPlayer) player;
         if (player.inventory.getMainHandStack().getItem() == Items.GOLDEN_SHOVEL && !isSame(claimPlayer.getLeftPosition(), pos)) {
-            claimPlayer.sendMessage(new LiteralText("Position #1 set to " + pos.getX() + " " + pos.getZ()).formatted(Formatting.GREEN));
+            claimPlayer.sendMessage(TextComponent.of("<gradient:red:yellow> Position #1 set to " + pos.getX() + " " + pos.getZ()));
             claimPlayer.setLeftPosition(pos);
             onClaimAddCorner();
         }

--- a/src/main/java/me/drex/itsours/mixin/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/me/drex/itsours/mixin/ServerPlayerInteractionManagerMixin.java
@@ -2,7 +2,12 @@ package me.drex.itsours.mixin;
 
 import me.drex.itsours.ItsOursMod;
 import me.drex.itsours.user.ClaimPlayer;
-import me.drex.itsours.util.TextComponent;
+import me.drex.itsours.util.Color;
+import me.drex.itsours.util.TextComponentUtil;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
@@ -36,7 +41,7 @@ public class ServerPlayerInteractionManagerMixin {
         ClaimPlayer claimPlayer = (ClaimPlayer) player;
         BlockPos pos = hitResult.getBlockPos();
         if (stack.getItem() == Items.GOLDEN_SHOVEL && !isSame(claimPlayer.getRightPosition(), pos)) {
-            claimPlayer.sendMessage(new LiteralText("Position #2 set to " + pos.getX() + " " + pos.getZ()).formatted(Formatting.GREEN));
+            claimPlayer.sendMessage(Component.text("Position #2 set to " + pos.getX() + " " + pos.getZ()).color(Color.LIGHT_GREEN));
             claimPlayer.setRightPosition(pos);
             onClaimAddCorner();
         }
@@ -56,7 +61,7 @@ public class ServerPlayerInteractionManagerMixin {
     private void onMine(BlockPos pos, PlayerActionC2SPacket.Action action, Direction direction, int worldHeight, CallbackInfo ci) {
         ClaimPlayer claimPlayer = (ClaimPlayer) player;
         if (player.inventory.getMainHandStack().getItem() == Items.GOLDEN_SHOVEL && !isSame(claimPlayer.getLeftPosition(), pos)) {
-            claimPlayer.sendMessage(TextComponent.of("<gradient:red:yellow> Position #1 set to " + pos.getX() + " " + pos.getZ()));
+            claimPlayer.sendMessage(Component.text("Position #1 set to " + pos.getX() + " " + pos.getZ()).color(Color.LIGHT_GREEN));
             claimPlayer.setLeftPosition(pos);
             onClaimAddCorner();
         }

--- a/src/main/java/me/drex/itsours/mixin/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/me/drex/itsours/mixin/ServerPlayerInteractionManagerMixin.java
@@ -49,14 +49,14 @@ public class ServerPlayerInteractionManagerMixin {
             onClaimAddCorner();
         }
         //TODO: Make sure the chest was actually placed
-        if (stack.getItem() == Items.CHEST && ItsOursMod.INSTANCE.getClaimList().get(player.getUuid()).isEmpty()) {
-            claimPlayer.sendMessage(Component.text("This " + stack.getName().getString().toLowerCase() + " is not protected, click this message to create a claim, to protect it").color(Color.ORANGE).clickEvent(net.kyori.adventure.text.event.ClickEvent.runCommand("/claim create")));
-            BlockPos blockPos = hitResult.getBlockPos().offset(hitResult.getSide());
-            if (!claimPlayer.arePositionsSet()) {
-                claimPlayer.setRightPosition(new BlockPos(blockPos.getX() + 3, blockPos.getY(), blockPos.getZ() + 3));
-                claimPlayer.setLeftPosition(new BlockPos(blockPos.getX() - 3, blockPos.getY(), blockPos.getZ() - 3));
-            }
-        }
+//        if (stack.getItem() == Items.CHEST && ItsOursMod.INSTANCE.getClaimList().get(player.getUuid()).isEmpty()) {
+//            claimPlayer.sendMessage(Component.text("This " + stack.getName().getString().toLowerCase() + " is not protected, click this message to create a claim, to protect it").color(Color.ORANGE).clickEvent(net.kyori.adventure.text.event.ClickEvent.runCommand("/claim create")));
+//            BlockPos blockPos = hitResult.getBlockPos().offset(hitResult.getSide());
+//            if (!claimPlayer.arePositionsSet()) {
+//                claimPlayer.setRightPosition(new BlockPos(blockPos.getX() + 3, blockPos.getY(), blockPos.getZ() + 3));
+//                claimPlayer.setLeftPosition(new BlockPos(blockPos.getX() - 3, blockPos.getY(), blockPos.getZ() - 3));
+//            }
+//        }
     }
 
     @Inject(method = "processBlockBreakingAction", at = @At("HEAD"))

--- a/src/main/java/me/drex/itsours/mixin/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/me/drex/itsours/mixin/ServerPlayerInteractionManagerMixin.java
@@ -27,7 +27,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(ServerPlayerInteractionManager.class)
 public class ServerPlayerInteractionManagerMixin {
 
-    @Shadow public ServerPlayerEntity player;
+    @Shadow
+    public ServerPlayerEntity player;
 
     @Inject(method = "interactBlock", at = @At("HEAD"))
     private void onInteract(ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir) {
@@ -37,6 +38,16 @@ public class ServerPlayerInteractionManagerMixin {
             claimPlayer.sendMessage(new LiteralText("Position #2 set to " + pos.getX() + " " + pos.getZ()).formatted(Formatting.GREEN));
             claimPlayer.setRightPosition(pos);
             onClaimAddCorner();
+        }
+        //TODO: Make sure the chest was actually placed
+        if (stack.getItem() == Items.CHEST && ItsOursMod.INSTANCE.getClaimList().get(player.getUuid()).isEmpty()) {
+            claimPlayer.sendMessage(new LiteralText("This " + stack.getName().getString().toLowerCase() + " is not protected, click this message to create a claim, to protect it").formatted(Formatting.GOLD)
+                    .styled(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/claim create"))));
+            BlockPos blockPos = hitResult.getBlockPos().offset(hitResult.getSide());
+            if (!claimPlayer.arePositionsSet()) {
+                claimPlayer.setRightPosition(new BlockPos(blockPos.getX() + 3, blockPos.getY(), blockPos.getZ() + 3));
+                claimPlayer.setLeftPosition(new BlockPos(blockPos.getX() - 3, blockPos.getY(), blockPos.getZ() - 3));
+            }
         }
     }
 

--- a/src/main/java/me/drex/itsours/user/ClaimPlayer.java
+++ b/src/main/java/me/drex/itsours/user/ClaimPlayer.java
@@ -1,6 +1,7 @@
 package me.drex.itsours.user;
 
 import me.drex.itsours.claim.AbstractClaim;
+import net.kyori.adventure.text.Component;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
@@ -31,6 +32,8 @@ public interface ClaimPlayer {
     void sendError(String error);
 
     void sendMessage(Text text);
+
+    void sendMessage(Component component);
 
     void toggleFlight();
 

--- a/src/main/java/me/drex/itsours/util/Color.java
+++ b/src/main/java/me/drex/itsours/util/Color.java
@@ -1,0 +1,37 @@
+package me.drex.itsours.util;
+
+import net.kyori.adventure.text.format.TextColor;
+
+public class Color implements TextColor {
+
+    public static final Color DARK_GRAY = new Color("dark_gray", 0x595959);
+    public static final Color GRAY = new Color("gray", 0x7F7F7F);
+    public static final Color LIGHT_GRAY = new Color("light_gray", 0xA5A5A5);
+    public static final Color WHITE = new Color("white", 0xF2F2F2);
+    public static final Color RED = new Color("red", 0xF94144);
+    public static final Color ORANGE = new Color("orange", 0xF3722C);
+    public static final Color YELLOW = new Color("yellow", 0xFFDA1F);
+    public static final Color DARK_GREEN = new Color("dark_green", 0x386E0D);
+    public static final Color GREEN = new Color("green",0x34EA7A);
+    public static final Color LIGHT_GREEN = new Color("light_green", 0x6CF628);
+    public static final Color LIGHT_BLUE = new Color("light_blue", 0x37E6E3);
+    public static final Color AQUA = new Color("aqua", 0x48BFE3);
+    public static final Color BLUE = new Color("blue", 0x277DA1);
+    public static final Color DARK_BLUE = new Color("dark_blue", 0x30329C);
+    public static final Color PINK = new Color("pink", 0xCA68C2);
+    public static final Color PURPLE = new Color("purple", 0xA63A9D);
+    public static final Color DARK_PURPLE = new Color("dark_purple", 0x7400B8);
+    public static final Color[] COLORS = {DARK_GRAY, GRAY, LIGHT_GRAY, WHITE, RED, ORANGE, YELLOW, DARK_GREEN, GREEN, LIGHT_GREEN, LIGHT_BLUE, AQUA, BLUE, DARK_BLUE, PINK, PURPLE, DARK_PURPLE};
+
+    public final int value;
+    public final String name;
+    Color(String name, int color) {
+        this.name = name;
+        this.value = color;
+    }
+
+    @Override
+    public int value() {
+        return this.value;
+    }
+}

--- a/src/main/java/me/drex/itsours/util/Color.java
+++ b/src/main/java/me/drex/itsours/util/Color.java
@@ -34,4 +34,8 @@ public class Color implements TextColor {
     public int value() {
         return this.value;
     }
+
+    public String stringValue() {
+        return "#" + Integer.toHexString(this.value);
+    }
 }

--- a/src/main/java/me/drex/itsours/util/TextComponent.java
+++ b/src/main/java/me/drex/itsours/util/TextComponent.java
@@ -1,0 +1,30 @@
+package me.drex.itsours.util;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.minecraft.text.Text;
+
+public class TextComponent {
+
+    public static Text from(final Component component) {
+        return Text.Serializer.fromJson(GsonComponentSerializer.gson().serialize(component));
+    }
+
+    public static Component toComponent(final Text text) {
+        return GsonComponentSerializer.gson().deserialize(Text.Serializer.toJson(text));
+    }
+
+    public static Component of(final String raw) {
+        return of(raw, true);
+    }
+
+    public static Component of(final String raw, final boolean markdown) {
+        if (markdown) {
+            return MiniMessage.markdown().parse(raw);
+        }
+
+        return MiniMessage.get().parse(raw);
+    }
+
+}

--- a/src/main/java/me/drex/itsours/util/TextComponentUtil.java
+++ b/src/main/java/me/drex/itsours/util/TextComponentUtil.java
@@ -11,6 +11,10 @@ public class TextComponentUtil {
         return Text.Serializer.fromJson(GsonComponentSerializer.gson().serialize(component));
     }
 
+    public static Text error(String error) {
+        return from(of(error).color(Color.RED));
+    }
+
     public static Component toComponent(final Text text) {
         return GsonComponentSerializer.gson().deserialize(Text.Serializer.toJson(text));
     }

--- a/src/main/java/me/drex/itsours/util/TextComponentUtil.java
+++ b/src/main/java/me/drex/itsours/util/TextComponentUtil.java
@@ -5,7 +5,7 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.minecraft.text.Text;
 
-public class TextComponent {
+public class TextComponentUtil {
 
     public static Text from(final Component component) {
         return Text.Serializer.fromJson(GsonComponentSerializer.gson().serialize(component));

--- a/src/main/java/me/drex/itsours/util/TextUtil.java
+++ b/src/main/java/me/drex/itsours/util/TextUtil.java
@@ -1,13 +1,14 @@
 package me.drex.itsours.util;
 
+import net.kyori.adventure.text.Component;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
 public class TextUtil {
 
-    public static Text format(boolean value) {
-        return new LiteralText(String.valueOf(value)).formatted(value ? Formatting.GREEN : Formatting.RED);
+    public static Component format(boolean value) {
+        return Component.text(String.valueOf(value)).color(value ? Color.LIGHT_GREEN : Color.RED);
     }
 
 }

--- a/src/main/resources/itsours.mixins.json
+++ b/src/main/resources/itsours.mixins.json
@@ -4,6 +4,7 @@
   "package": "me.drex.itsours.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "BlockItemMixin",
     "EntityMixin",
     "LevelStorageSessionMixin",
     "ServerPlayerEntityMixin",


### PR DESCRIPTION
This PR adds a new claim fly and a beginner help system. It also adds support for [MiniMessage](https://docs.adventure.kyori.net/).
- implemented claim help, which helps the player create their first claim
- added support for MiniMessage and changed all feedbacks to use it
- added /improved claim fly